### PR TITLE
Add alire.toml file to tests/ and instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@ Progress indicators for command line tools in Ada.
 
 [![Build Status](https://github.com/pyjarrett/progress_indicators/actions/workflows/build.yml/badge.svg)](https://github.com/pyjarrett/progress_indicators/actions)
 [![Alire](https://img.shields.io/endpoint?url=https://alire.ada.dev/badges/progress_indicators.json)](https://alire.ada.dev/crates/progress_indicators.html)
+
+## Examples
+
+To build and run the examples, execute the following:
+
+```sh
+cd tests
+alr run
+```

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -1,0 +1,18 @@
+name = "progress_indicators_tests"
+description = "Examples displaying progress in command line tools."
+version = "0.0.1"
+website = "https://github.com/pyjarrett/progress_indicators"
+authors = ["the progress_indicators authors"]
+licenses = "Apache-2.0"
+
+maintainers = ["Paul Jarrett <jarrett.paul.young@gmail.com>"]
+maintainers-logins = ["pyjarrett"]
+tags = ["command-line", "console", "terminal", "progress"]
+
+executables = ["progress_indicators_test"]
+
+[[depends-on]]
+progress_indicators = "~0.0.1"
+
+[[pins]]
+progress_indicators = { path = ".." }


### PR DESCRIPTION
It uses a pin so that it will use the local version of progress_indicators instead of any version in the user's Alire index.

Fixes #4 